### PR TITLE
When updating related entities, Eloquent events such as `saved` and `updated` are NOT fired.

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -72,8 +72,11 @@ class ServiceProvider extends BaseServiceProvider
             }
 
             foreach ($updatedRows as $row) {
-                $this->getRelated()->where($relatedKeyName, $castKey(array_get($row, $relatedKeyName)))
-                    ->update($row);
+                $related = $this->getRelated()
+                    ->where($relatedKeyName, $castKey(array_get($row, $relatedKeyName)))
+                    ->first()
+                    ->fill($row)
+                    ->save();
             }
 
             $changes['updated'] = $castKeys(array_pluck($updatedRows, $relatedKeyName));


### PR DESCRIPTION
# The problem
When using the `update()` method without retrieving the entity first, the Laravel events `updating`, `updated`, `saving` and `saved` are not fired. I noticed this when I was working on an `Event` for my application and I was wondering why the `saved` event was only fired when a new related entity is added, but it is not fired when an existing entity is edited.

https://github.com/alfa6661/laravel-hasmany-sync/blob/16aac13f31050d47a8adff761fd5f6ae314476bb/src/ServiceProvider.php#L75-L76

The reason why `saved` event is fired when a new related entity is added is because `createMany` method is used.

https://github.com/alfa6661/laravel-hasmany-sync/blob/16aac13f31050d47a8adff761fd5f6ae314476bb/src/ServiceProvider.php#L68

# Possible solution?
I would solve the issue by replacing the use of `update` method with
```
$related = $this->getRelated()
                    ->where($relatedKeyName, $castKey(array_get($row, $relatedKeyName)))
                    ->first()
                    ->fill($row)
                    ->save();
```

# Literature
https://laravel.com/docs/8.x/eloquent#updates
https://stackoverflow.com/questions/41295032/laravel-eloquent-model-update-event-is-not-fired
